### PR TITLE
Hierarchy levels formatting fix

### DIFF
--- a/src/bootstraptable-treeview.js
+++ b/src/bootstraptable-treeview.js
@@ -154,7 +154,8 @@
                     }
                     rows.push(n);
                     if(subChild!=null && subChild.length>0){
-                        levelStep++;
+                        //levelStep++;
+                        levelStep = childLevel + 1; // format as per the childLevel, better formatting of levels after 3rd or 4th levels
                         g(subChild);
                     }else{
                         levelStep=1;


### PR DESCRIPTION
Better formatting by adopting the childLevel and adjusting the span margin accordingly. The earlier formatting was getting distorted when in the 3rd level onwards.